### PR TITLE
Players get more clues when a new round starts

### DIFF
--- a/Assets/HotPotato/Scripts/Managers/PlayerManager.cs
+++ b/Assets/HotPotato/Scripts/Managers/PlayerManager.cs
@@ -142,7 +142,6 @@ namespace HotPotato.Managers
         private void StartNextRoundServerRpc()
         {
             ResetPlayers();
-            EventBus<RoundStartedEvent>.Raise(new RoundStartedEvent());
 
             foreach (var player in _remainingPlayers)
             {
@@ -156,7 +155,6 @@ namespace HotPotato.Managers
         private void StartNextMatchServerRpc()
         {
             ResetPlayers();
-            EventBus<RoundStartedEvent>.Raise(new RoundStartedEvent());
 
             foreach (var player in _remainingPlayers)
             {

--- a/Assets/HotPotato/Scripts/UI/UIManager.cs
+++ b/Assets/HotPotato/Scripts/UI/UIManager.cs
@@ -31,7 +31,7 @@ namespace HotPotato.UI
         
         private Dictionary<BombClueType, Dictionary<int, int>> _clueTypeData;
         private List<ClueFieldUI> _clueFieldUIList = new();
-
+        
         public override void OnStartNetwork()
         {
             base.NetworkManager.RegisterInstance(this);


### PR DESCRIPTION
Closes #74 

## The Fix
When a new round starts each player gets exactly one set of clues, no matter how many there are in the match. 

## The Error
The round start event was raised twice on the server, once on the server rpc and once on the player's observers rpc. Since we are doing client hosting we need to make sure that events are only raised once, either by skipping on host or by not calling on the server.